### PR TITLE
⬆️ Run tests on Java 17

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -14,9 +14,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: 17
     - name: Generate Docs
       run: gradle javadoc
     - name: Commit files

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -13,9 +13,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Release build
         run: gradle assemble
       - name: Source jar

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@
 
 name: Run Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
@@ -10,13 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 16]
+        java: [8, 11, 17]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Java ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Build with Gradle
       run: gradle build


### PR DESCRIPTION
- Start testing against Java 17 (LTS).
- Stop testing on Java 16 (non-LTS) as it went out of support in September 2021.
- Move all workflows to v2 of actions and java 17.

Closes #23